### PR TITLE
Fix getinstance

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,9 @@
         "ext-pcntl": "*",
         "psr/log": "1.0.0"
     },
+    "require-dev": {
+        "phpunit/phpunit": "~4"
+    },
     "autoload": {
         "psr-0": {
             "Qless": "lib"

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,1012 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "hash": "285cc993440f499bb675e85051758c7f",
+    "packages": [
+        {
+            "name": "psr/log",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/fe0936ee26643249e916849d48e3a51d5f5e278b",
+                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Psr\\Log\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "time": "2012-12-21 11:40:51"
+        }
+    ],
+    "packages-dev": [
+        {
+            "name": "doctrine/instantiator",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3,<8.0-DEV"
+            },
+            "require-dev": {
+                "athletic/athletic": "~0.1.8",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpunit/phpunit": "~4.0",
+                "squizlabs/php_codesniffer": "~2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "http://ocramius.github.com/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://github.com/doctrine/instantiator",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "time": "2015-06-14 21:17:01"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "d68dbdc53dc358a816f00b300704702b2eaff7b8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/d68dbdc53dc358a816f00b300704702b2eaff7b8",
+                "reference": "d68dbdc53dc358a816f00b300704702b2eaff7b8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "suggest": {
+                "dflydev/markdown": "~1.0",
+                "erusev/parsedown": "~1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "phpDocumentor": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "mike.vanriel@naenius.com"
+                }
+            ],
+            "time": "2015-02-03 12:10:50"
+        },
+        {
+            "name": "phpspec/prophecy",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/prophecy.git",
+                "reference": "80da5500014051b9e70740f183c5e5586f38f977"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/80da5500014051b9e70740f183c5e5586f38f977",
+                "reference": "80da5500014051b9e70740f183c5e5586f38f977",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.0.2",
+                "phpdocumentor/reflection-docblock": "~2.0",
+                "sebastian/comparator": "~1.1"
+            },
+            "require-dev": {
+                "phpspec/phpspec": "~2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Prophecy\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Konstantin Kudryashov",
+                    "email": "ever.zet@gmail.com",
+                    "homepage": "http://everzet.com"
+                },
+                {
+                    "name": "Marcello Duarte",
+                    "email": "marcello.duarte@gmail.com"
+                }
+            ],
+            "description": "Highly opinionated mocking framework for PHP 5.3+",
+            "homepage": "https://github.com/phpspec/prophecy",
+            "keywords": [
+                "Double",
+                "Dummy",
+                "fake",
+                "mock",
+                "spy",
+                "stub"
+            ],
+            "time": "2015-08-13 10:25:47"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "2.2.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "ab2283bf4a836d7f2ec5f33c15d6802d9f4cb512"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ab2283bf4a836d7f2ec5f33c15d6802d9f4cb512",
+                "reference": "ab2283bf4a836d7f2ec5f33c15d6802d9f4cb512",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "phpunit/php-file-iterator": "~1.3",
+                "phpunit/php-text-template": "~1.2",
+                "phpunit/php-token-stream": "~1.3",
+                "sebastian/environment": "^1.3.2",
+                "sebastian/version": "~1.0"
+            },
+            "require-dev": {
+                "ext-xdebug": ">=2.1.4",
+                "phpunit/phpunit": "~4"
+            },
+            "suggest": {
+                "ext-dom": "*",
+                "ext-xdebug": ">=2.2.1",
+                "ext-xmlwriter": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "time": "2015-09-01 12:25:27"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
+                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "time": "2015-06-21 13:08:43"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "time": "2015-06-21 13:50:34"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "3e82f4e9fc92665fafd9157568e4dcb01d014e5b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3e82f4e9fc92665fafd9157568e4dcb01d014e5b",
+                "reference": "3e82f4e9fc92665fafd9157568e4dcb01d014e5b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "time": "2015-06-21 08:01:12"
+        },
+        {
+            "name": "phpunit/php-token-stream",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
+                "reference": "92d472f7ac0cd45b7f6d66cb807646432cf89f5d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/92d472f7ac0cd45b7f6d66cb807646432cf89f5d",
+                "reference": "92d472f7ac0cd45b7f6d66cb807646432cf89f5d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Wrapper around PHP's tokenizer extension.",
+            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
+            "keywords": [
+                "tokenizer"
+            ],
+            "time": "2015-08-18 15:47:59"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "4.8.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "473776571bfcdcf416faca4d31f52c4e5740a9c2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/473776571bfcdcf416faca4d31f52c4e5740a9c2",
+                "reference": "473776571bfcdcf416faca4d31f52c4e5740a9c2",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-reflection": "*",
+                "ext-spl": "*",
+                "php": ">=5.3.3",
+                "phpspec/prophecy": "^1.3.1",
+                "phpunit/php-code-coverage": "~2.1",
+                "phpunit/php-file-iterator": "~1.4",
+                "phpunit/php-text-template": "~1.2",
+                "phpunit/php-timer": ">=1.0.6",
+                "phpunit/phpunit-mock-objects": "~2.3",
+                "sebastian/comparator": "~1.1",
+                "sebastian/diff": "~1.2",
+                "sebastian/environment": "~1.3",
+                "sebastian/exporter": "~1.2",
+                "sebastian/global-state": "~1.0",
+                "sebastian/version": "~1.0",
+                "symfony/yaml": "~2.1|~3.0"
+            },
+            "suggest": {
+                "phpunit/php-invoker": "~1.1"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.8.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "time": "2015-09-05 08:36:58"
+        },
+        {
+            "name": "phpunit/phpunit-mock-objects",
+            "version": "2.3.x-dev",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
+                "reference": "5e2645ad49d196e020b85598d7c97e482725786a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/5e2645ad49d196e020b85598d7c97e482725786a",
+                "reference": "5e2645ad49d196e020b85598d7c97e482725786a",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.0.2",
+                "php": ">=5.3.3",
+                "phpunit/php-text-template": "~1.2",
+                "sebastian/exporter": "~1.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.4"
+            },
+            "suggest": {
+                "ext-soap": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Mock Object library for PHPUnit",
+            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
+            "keywords": [
+                "mock",
+                "xunit"
+            ],
+            "time": "2015-08-19 09:14:08"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/937efb279bd37a375bcadf584dec0726f84dbf22",
+                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "sebastian/diff": "~1.2",
+                "sebastian/exporter": "~1.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "http://www.github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "time": "2015-07-26 15:48:44"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "6899b3e33bfbd386d88b5eea5f65f563e8793051"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/6899b3e33bfbd386d88b5eea5f65f563e8793051",
+                "reference": "6899b3e33bfbd386d88b5eea5f65f563e8793051",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "http://www.github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff"
+            ],
+            "time": "2015-06-22 14:15:55"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "6324c907ce7a52478eeeaede764f48733ef5ae44"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/6324c907ce7a52478eeeaede764f48733ef5ae44",
+                "reference": "6324c907ce7a52478eeeaede764f48733ef5ae44",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "time": "2015-08-03 06:14:51"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "f88f8936517d54ae6d589166810877fb2015d0a2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/f88f8936517d54ae6d589166810877fb2015d0a2",
+                "reference": "f88f8936517d54ae6d589166810877fb2015d0a2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "sebastian/recursion-context": "~1.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "time": "2015-08-09 04:23:41"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "23af31f402993cfd94e99cbc4b782e9a78eb0e97"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/23af31f402993cfd94e99cbc4b782e9a78eb0e97",
+                "reference": "23af31f402993cfd94e99cbc4b782e9a78eb0e97",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.2"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "time": "2015-06-21 15:11:22"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "994d4a811bafe801fb06dccbee797863ba2792ba"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/994d4a811bafe801fb06dccbee797863ba2792ba",
+                "reference": "994d4a811bafe801fb06dccbee797863ba2792ba",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "time": "2015-06-21 08:04:50"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "1.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
+                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "time": "2015-06-21 13:59:46"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Yaml.git",
+                "reference": "737b5ca48a451f5e4ed542aae7ed1ab6996bd7eb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Yaml/zipball/737b5ca48a451f5e4ed542aae7ed1ab6996bd7eb",
+                "reference": "737b5ca48a451f5e4ed542aae7ed1ab6996bd7eb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "~2.8|~3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Yaml Component",
+            "homepage": "https://symfony.com",
+            "time": "2015-08-24 07:21:16"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "dev",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=5.3.0",
+        "ext-pcntl": "*"
+    },
+    "platform-dev": []
+}

--- a/lib/Qless/Job.php
+++ b/lib/Qless/Job.php
@@ -387,18 +387,19 @@ class Job
         }
 
         if (!class_exists($this->klass_name)) {
-            throw new \Exception(
+            throw new QlessException(
                 'Could not find job class ' . $this->klass_name . '.'
             );
         }
 
-        if (!method_exists($this->klass_name, $this->data['performMethod'])) {
-            throw new \Exception(
+        $this->instance = new $this->klass_name;
+
+        if (!method_exists($this->instance, $this->data['performMethod'])) {
+            throw new QlessException(
                 'Job class ' . $this->klass_name . ' does not contain perform method ' . $this->data['performMethod']
             );
         }
 
-        $this->instance = new $this->klass_name;
 
         return $this->instance;
     }

--- a/lib/Qless/Job.php
+++ b/lib/Qless/Job.php
@@ -394,9 +394,12 @@ class Job
 
         $this->instance = new $this->klass_name;
 
-        if (!method_exists($this->instance, $this->data['performMethod'])) {
+        $performMethod = is_array($this->data) && array_key_exists('performMethod', $this->data) ?
+            $this->data['performMethod'] : 'perform';
+
+        if (!method_exists($this->instance, $performMethod)) {
             throw new QlessException(
-                'Job class ' . $this->klass_name . ' does not contain perform method ' . $this->data['performMethod']
+                'Job class ' . $this->klass_name . ' does not contain perform method: ' . $performMethod
             );
         }
 

--- a/lib/Qless/Job.php
+++ b/lib/Qless/Job.php
@@ -341,7 +341,7 @@ class Job
         try {
             $instance = $this->getInstance();
 
-            $performMethod = $this->data['performMethod'];
+            $performMethod = $this->data['performMethod'] ?: 'perform';
 
             $instance->$performMethod($this);
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -38,8 +38,9 @@
     </groups>
 
     <php>
-        <env name="REDIS_HOST" value="192.168.50.130"/>
-        <env name="REDIS_PORT" value="6380"/>
+        <!-- uncomment to override -->
+        <!--<env name="REDIS_HOST" value="localhost"/>-->
+        <!--<env name="REDIS_PORT" value="6379"/>-->
     </php>
 
 </phpunit>

--- a/test/JobTest.php
+++ b/test/JobTest.php
@@ -5,6 +5,53 @@ require_once __DIR__ . '/QlessTest.php';
 class JobTest extends QlessTest
 {
     /**
+     * @expectedException \Qless\QlessException
+     */
+    public function testGetInstanceWithInvalidClassThrows() {
+        $queue = new Qless\Queue("testQueue", $this->client);
+        $this->client->config->set('heartbeat', -10);
+        $this->client->config->set('grace-period', 0);
+
+        $testData = ["performMethod" => 'myPerformMethod', "payload" => "otherData"];
+        $queue->put("ClassDoesNotExist", "jobTestDEF", $testData);
+
+        $job1 = $queue->pop("worker-1")[0];
+
+        $job1->getInstance();
+    }
+
+    /**
+     * @expectedException \Qless\QlessException
+     */
+    public function testGetInstanceWithInvalidPerformMethodThrows() {
+        $queue = new Qless\Queue("testQueue", $this->client);
+        $this->client->config->set('heartbeat', -10);
+        $this->client->config->set('grace-period', 0);
+
+        $testData = ["performMethod" => 'myNonexistantMethod', "payload" => "otherData"];
+        $queue->put("TestWorkerImpl", "jobTestDEF", $testData);
+
+        $job1 = $queue->pop("worker-1")[0];
+
+        $job1->getInstance();
+    }
+
+    public function testGetInstanceReturnsHandler() {
+        $queue = new Qless\Queue("testQueue", $this->client);
+        $this->client->config->set('heartbeat', -10);
+        $this->client->config->set('grace-period', 0);
+
+        $testData = ["performMethod" => 'myPerformMethod', "payload" => "otherData"];
+        $queue->put("TestWorkerImpl", "jobTestDEF", $testData);
+
+        $job1 = $queue->pop("worker-1")[0];
+
+        $instance = $job1->getInstance();
+
+        $this->assertInstanceOf(TestWorkerImpl::class, $instance);
+    }
+
+    /**
      * @expectedException \Qless\JobLostException
      */
     public function testHeartbeatForInvalidJobThrows() {
@@ -13,7 +60,7 @@ class JobTest extends QlessTest
         $this->client->config->set('grace-period', 0);
 
         $testData = ["performMethod" => 'myPerformMethod', "payload" => "otherData"];
-        $queue->put("Sample\\TestWorkerImpl", "jobTestDEF", $testData);
+        $queue->put("TestWorkerImpl", "jobTestDEF", $testData);
 
         $job1 = $queue->pop("worker-1")[0];
         $queue->pop("worker-2");
@@ -22,7 +69,7 @@ class JobTest extends QlessTest
 
     public function testCanGetCorrectTTL() {
         $queue = new Qless\Queue("testQueue", $this->client);
-        $queue->put("Sample\\TestWorkerImpl", "jobTestDEF", []);
+        $queue->put("TestWorkerImpl", "jobTestDEF", []);
         $job = $queue->pop("worker-1")[0];
         $ttl = $job->ttl();
         $this->assertGreaterThan(55, $ttl);
@@ -32,7 +79,7 @@ class JobTest extends QlessTest
         $queue = new Qless\Queue("testQueue", $this->client);
 
         $testData = ["performMethod" => 'myPerformMethod', "payload" => "otherData"];
-        $queue->put("Sample\\TestWorkerImpl", "jobTestDEF", $testData);
+        $queue->put("TestWorkerImpl", "jobTestDEF", $testData);
 
         $job1 = $queue->pop("worker-1")[0];
         $res = $job1->complete();
@@ -43,7 +90,7 @@ class JobTest extends QlessTest
         $queue = new Qless\Queue("testQueue", $this->client);
 
         $testData = ["performMethod" => 'myPerformMethod', "payload" => "otherData"];
-        $queue->put("Sample\\TestWorkerImpl", "jid", $testData);
+        $queue->put("TestWorkerImpl", "jid", $testData);
 
         $job1 = $queue->pop("worker-1")[0];
         $res = $job1->fail('account', 'failed to connect');
@@ -53,11 +100,13 @@ class JobTest extends QlessTest
         $this->assertEmpty($job1);
     }
 
+    #region retry
+
     public function testRetryDoesReturnJobAndDefaultsToFiveRetries() {
         $queue = new Qless\Queue("testQueue", $this->client);
 
         $testData = ["performMethod" => 'myPerformMethod', "payload" => "otherData"];
-        $queue->put("Sample\\TestWorkerImpl", "jid", $testData);
+        $queue->put("TestWorkerImpl", "jid", $testData);
 
         $job1 = $queue->pop("worker-1")[0];
         $remaining = $job1->retry('account', 'failed to connect');
@@ -71,7 +120,7 @@ class JobTest extends QlessTest
         $queue = new Qless\Queue("testQueue", $this->client);
 
         $testData = ["performMethod" => 'myPerformMethod', "payload" => "otherData"];
-        $queue->put("Sample\\TestWorkerImpl", "jid", $testData, 0, 1);
+        $queue->put("TestWorkerImpl", "jid", $testData, 0, 1);
 
         $job1 = $queue->pop("worker-1")[0];
         $remaining = $job1->retry('account', 'failed to connect');
@@ -85,7 +134,7 @@ class JobTest extends QlessTest
         $queue = new Qless\Queue("testQueue", $this->client);
 
         $testData = ["performMethod" => 'myPerformMethod', "payload" => "otherData"];
-        $queue->put("Sample\\TestWorkerImpl", "jid", $testData, 0, 0);
+        $queue->put("TestWorkerImpl", "jid", $testData, 0, 0);
 
         $job1 = $queue->pop("worker-1")[0];
         $remaining = $job1->retry('account', 'failed to connect');
@@ -96,7 +145,7 @@ class JobTest extends QlessTest
         $queue = new Qless\Queue("testQueue", $this->client);
 
         $testData = ["performMethod" => 'myPerformMethod', "payload" => "otherData"];
-        $queue->put("Sample\\TestWorkerImpl", "jid", $testData, 0, 0);
+        $queue->put("TestWorkerImpl", "jid", $testData, 0, 0);
 
         $job1 = $queue->pop("worker-1")[0];
         $job1->retry('account', 'failed to connect');
@@ -105,12 +154,16 @@ class JobTest extends QlessTest
         $this->assertEmpty($job1);
     }
 
+    #endregion
+
+    #region cancel
+
     public function testCancelRemovesJob() {
         $queue = new Qless\Queue("testQueue", $this->client);
 
         $testData = ["performMethod" => 'myPerformMethod', "payload" => "otherData"];
-        $queue->put("Sample\\TestWorkerImpl", "jid-1", $testData, 0, 0);
-        $queue->put("Sample\\TestWorkerImpl", "jid-2", $testData, 0, 0);
+        $queue->put("TestWorkerImpl", "jid-1", $testData, 0, 0);
+        $queue->put("TestWorkerImpl", "jid-2", $testData, 0, 0);
 
         $job1 = $queue->pop("worker-1")[0];
         $res = $job1->cancel();
@@ -122,8 +175,8 @@ class JobTest extends QlessTest
         $queue = new Qless\Queue("testQueue", $this->client);
 
         $testData = ["performMethod" => 'myPerformMethod', "payload" => "otherData"];
-        $queue->put("Sample\\TestWorkerImpl", "jid-1", $testData, 0, 0);
-        $queue->put("Sample\\TestWorkerImpl", "jid-2", $testData, 0, 0, true, 0, [], 0, [], ['jid-1']);
+        $queue->put("TestWorkerImpl", "jid-1", $testData, 0, 0);
+        $queue->put("TestWorkerImpl", "jid-2", $testData, 0, 0, true, 0, [], 0, [], ['jid-1']);
 
         $job1 = $queue->pop("worker-1")[0];
         $res = $job1->cancel(true);
@@ -138,19 +191,21 @@ class JobTest extends QlessTest
         $queue = new Qless\Queue("testQueue", $this->client);
 
         $testData = ["performMethod" => 'myPerformMethod', "payload" => "otherData"];
-        $queue->put("Sample\\TestWorkerImpl", "jid-1", $testData, 0, 0);
-        $queue->put("Sample\\TestWorkerImpl", "jid-2", $testData, 0, 0, true, 0, [], 0, [], ['jid-1']);
+        $queue->put("TestWorkerImpl", "jid-1", $testData, 0, 0);
+        $queue->put("TestWorkerImpl", "jid-2", $testData, 0, 0, true, 0, [], 0, [], ['jid-1']);
 
         $job1 = $queue->pop("worker-1")[0];
         $job1->cancel();
     }
+
+    #endregion
 
     #region tags
 
     public function testItCanAddTagsToAJobWithNoExistingTags() {
         $queue = new Qless\Queue("testQueue", $this->client);
         $testData = ["performMethod" => 'myPerformMethod', "payload" => "otherData"];
-        $queue->put("Sample\\TestWorkerImpl", "jid-1", $testData, 0, 0);
+        $queue->put("TestWorkerImpl", "jid-1", $testData, 0, 0);
 
         $job1 = $queue->pop("worker-1")[0];
         $job1->tag('a', 'b');
@@ -162,7 +217,7 @@ class JobTest extends QlessTest
     public function testItCanAddTagsToAJobWithExistingTags() {
         $queue = new Qless\Queue("testQueue", $this->client);
         $testData = ["performMethod" => 'myPerformMethod', "payload" => "otherData"];
-        $queue->put("Sample\\TestWorkerImpl", "jid-1", $testData, 0, 0, true, 0, [], 0, ['1', '2']);
+        $queue->put("TestWorkerImpl", "jid-1", $testData, 0, 0, true, 0, [], 0, ['1', '2']);
 
         $job1 = $queue->pop("worker-1")[0];
         $job1->tag('a', 'b');
@@ -174,7 +229,7 @@ class JobTest extends QlessTest
     public function testItCanRemoveExistingTags() {
         $queue = new Qless\Queue("testQueue", $this->client);
         $testData = ["performMethod" => 'myPerformMethod', "payload" => "otherData"];
-        $queue->put("Sample\\TestWorkerImpl", "jid-1", $testData, 0, 0, true, 0, [], 0, ['1', '2', '3']);
+        $queue->put("TestWorkerImpl", "jid-1", $testData, 0, 0, true, 0, [], 0, ['1', '2', '3']);
 
         $job1 = $queue->pop("worker-1")[0];
         $job1->untag('2', '3');
@@ -191,7 +246,7 @@ class JobTest extends QlessTest
         $queue = new Qless\Queue("testQueue", $this->client);
 
         $testData = ["performMethod" => 'myPerformMethod', "payload" => "otherData"];
-        $queue->put("Sample\\TestWorkerImpl", "jid-1", $testData, 0, 0, true, 1, [], 5, ['tag1','tag2']);
+        $queue->put("TestWorkerImpl", "jid-1", $testData, 0, 0, true, 1, [], 5, ['tag1','tag2']);
 
         $job = $queue->pop("worker-1")[0];
         $job->requeue();
@@ -206,7 +261,7 @@ class JobTest extends QlessTest
         $queue = new Qless\Queue("testQueue", $this->client);
 
         $testData = ["performMethod" => 'myPerformMethod', "payload" => "otherData"];
-        $queue->put("Sample\\TestWorkerImpl", "jid-1", $testData, 0, 0, true, 1, [], 5, ['tag1','tag2']);
+        $queue->put("TestWorkerImpl", "jid-1", $testData, 0, 0, true, 1, [], 5, ['tag1','tag2']);
 
         $job = $queue->pop("worker-1")[0];
         $job->requeue(['tags' => ['nnn']]);
@@ -224,7 +279,7 @@ class JobTest extends QlessTest
         $queue = new Qless\Queue("testQueue", $this->client);
 
         $testData = ["performMethod" => 'myPerformMethod', "payload" => "otherData"];
-        $queue->put("Sample\\TestWorkerImpl", "jid-1", $testData, 0, 0, true, 1, [], 5, ['tag1','tag2']);
+        $queue->put("TestWorkerImpl", "jid-1", $testData, 0, 0, true, 1, [], 5, ['tag1','tag2']);
 
         $job = $queue->pop("worker-1")[0];
         $this->client->cancel('jid-1');

--- a/test/QlessTest.php
+++ b/test/QlessTest.php
@@ -8,7 +8,7 @@ require_once __DIR__ . '/LuaTester.php';
 /**
  * Base class for qless-php testing
  */
-class QlessTest extends PHPUnit_Framework_TestCase {
+abstract class QlessTest extends PHPUnit_Framework_TestCase {
 
     static $REDIS_HOST;
     static $REDIS_PORT;

--- a/test/QlessTest.php
+++ b/test/QlessTest.php
@@ -3,6 +3,7 @@
 require_once __DIR__ . '/../lib/Qless/Client.php';
 require_once __DIR__ . '/../lib/Qless/Queue.php';
 require_once __DIR__ . '/../lib/Qless/Jobs.php';
+require_once __DIR__ . '/../demo/TestWorkerImpl.php';
 require_once __DIR__ . '/LuaTester.php';
 
 /**


### PR DESCRIPTION
Currently the getInstance method of the Job class uses method_exists with a string as the first argument when it should be an instance of an object.
PR also contains tests around getInstance and defaults the "perform" method to "perform" if not given.
