### PR TITLE
Unit tests for Job:getInstance, fix QlessTest class to be abstract

### DIFF
--- a/test/QlessTest.php
+++ b/test/QlessTest.php
@@ -3,12 +3,13 @@
 require_once __DIR__ . '/../lib/Qless/Client.php';
 require_once __DIR__ . '/../lib/Qless/Queue.php';
 require_once __DIR__ . '/../lib/Qless/Jobs.php';
+require_once __DIR__ . '/../demo/TestWorkerImpl.php';
 require_once __DIR__ . '/LuaTester.php';
 
 /**
  * Base class for qless-php testing
  */
-class QlessTest extends PHPUnit_Framework_TestCase {
+abstract class QlessTest extends PHPUnit_Framework_TestCase {
 
     static $REDIS_HOST;
     static $REDIS_PORT;


### PR DESCRIPTION
Make QlessTest abstract so phpunit does not try to run it (shows failure)
Add tests for Job:getInstance
Fixed TestWorkerImpl class name because it is not namespaced (tests never actually got far enough to use it), included it for base test class
